### PR TITLE
Set the pwsh invoke encoding as UTF-8

### DIFF
--- a/Profile.ps1
+++ b/Profile.ps1
@@ -1,6 +1,9 @@
 # in profile:
 # . $env:USERPROFILE\.config\pwsh-profile\user_profile.ps1
 
+# Encoding
+$OutputEncoding = [console]::InputEncoding = [console]::OutputEncoding = [Text.UTF8Encoding]::UTF8
+
 # Location
 # ~/.config/powershell/user_profile.ps1
 


### PR DESCRIPTION
Set the pwsh invoke encoding as UTF-8 to avoid the zh-CN description present like this, seems issue from carapace completion

![image](https://github.com/user-attachments/assets/23ff79ba-7c2e-47a0-9e8e-e0bcfd993c05)
